### PR TITLE
Make it work on Desktop (Unix/Windows)

### DIFF
--- a/lib/localstorage.dart
+++ b/lib/localstorage.dart
@@ -40,9 +40,18 @@ class LocalStorage {
     });
   }
 
+  Future<Directory> _getDocumentDir() async {
+    if (Platform.isMacOS || Platform.isLinux) {
+      return Directory('${Platform.environment['HOME']}/.config');
+    } else if (Platform.isWindows) {
+      return Directory('${Platform.environment['UserProfile']}\\.config');
+    }
+    return await getApplicationDocumentsDirectory();
+  }
+
   _init() async {
     try {
-      final documentDir = await getApplicationDocumentsDirectory();
+      final documentDir = await _getDocumentDir();
       final path = documentDir.path;
 
       _file = File('$path/$_filename.json');


### PR DESCRIPTION
`getApplicationDocumentsDirectory` from path_provider hangs when running flutter on desktop (with desktop embedder).

This PR fixes this behavior and make it work on desktop as well, by saving the file to `$HOME/.config` folder.