### PR TITLE
version/v1.3.1-proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.1
+- update `README.md` documentation
+- bump `package_provider` dependency to address `getApplicationSupportDirectory`
+- fix `noSuchMethodError` in `_flush` according to PR [#15](https://github.com/lesnitsky/flutter_localstorage/pull/15) needed to get around issue [#14](https://github.com/lesnitsky/flutter_localstorage/issues/14)
+
 ## 1.3.0
 
 - add optional `path`argument to specify storage folder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.3.1
 - update `README.md` documentation
 - bump `package_provider` dependency to address `getApplicationSupportDirectory`
-- fix `noSuchMethodError` in `_flush` according to PR [#15](https://github.com/lesnitsky/flutter_localstorage/pull/15) needed to get around issue [#14](https://github.com/lesnitsky/flutter_localstorage/issues/14)
+- fix `noSuchMethodError` in `_flush`
 
 ## 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add dependency to `pubspec.yaml`
 ```yaml
 dependencies:
   ...
-  localstorage: ^1.2.0
+  localstorage: ^1.3.1
 ```
 
 Run in your terminal

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -52,14 +52,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.3+1"
+    version: "0.12.5"
   meta:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0+1"
+    version: "1.1.0"
   pedantic:
     dependency: transitive
     description:
@@ -94,7 +94,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -120,7 +120,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.8"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.4"
   typed_data:
     dependency: transitive
     description:
@@ -157,5 +157,5 @@ packages:
     source: hosted
     version: "2.0.8"
 sdks:
-  dart: ">=2.1.1-dev.0.0 <3.0.0"
+  dart: ">=2.2.0 <3.0.0"
   flutter: ">=0.1.4 <2.0.0"

--- a/lib/localstorage.dart
+++ b/lib/localstorage.dart
@@ -122,6 +122,7 @@ class LocalStorage {
   Future<void> _flush() async {
     final serialized = json.encode(_data);
     try {
+      await ready;
       await _file.writeAsString(serialized);
     } catch (e) {
       rethrow;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,7 +66,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0+1"
+    version: "1.1.0"
   pedantic:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: localstorage
 description: Simple json file-based storage fo flutter. Alternative to react-native AsyncStorage
-version: 1.3.0
+version: 1.3.1
 author: Andrei Lesnitsky <andrei.lesnitsky@gmail.com>
 homepage: https://github.com/lesnitsky/flutter_localstorage
 
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  path_provider: ^1.0.0
+  path_provider: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
**1.3.1**
- update `README.md` documentation
- bump `package_provider` dependency to address `getApplicationSupportDirectory`
- fix `noSuchMethodError` in `_flush` according to PR [#15](https://github.com/lesnitsky/flutter_localstorage/pull/15) needed to get around issue [#14](https://github.com/lesnitsky/flutter_localstorage/issues/14)