### PR TITLE
remove cached value by key when remove is called.

### DIFF
--- a/lib/src/directory/io.dart
+++ b/lib/src/directory/io.dart
@@ -65,6 +65,7 @@ class DirUtils implements LocalStorageImpl {
 
   @override
   Future<void> remove(String key) async {
+    _data.remove(key);
     await _writeFile(_data);
   }
 


### PR DESCRIPTION
fix deleteItem is not working on Andorid.