### PR TITLE
fix: update path_provider_fde to url_launcher_fde

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ In order to be able to use this package on desktop, add this to your `pubspec.ya
 ```pubspec.yaml
 dependencies:
   localstorage: ^3.0.0
-  path_provider_fde:
+  url_launcher_fde:
     git:
       url: https://github.com/google/flutter-desktop-embedding/
-      path: plugins/flutter_plugins/path_provider_fde
+      path: plugins/flutter_plugins/url_launcher_fde
 ```
 
 ## V2 -> v3 migration

--- a/README.md
+++ b/README.md
@@ -45,19 +45,6 @@ class SomeWidget extends StatelessWidget {
 }
 ```
 
-## Desktop support
-
-In order to be able to use this package on desktop, add this to your `pubspec.yaml`
-
-```pubspec.yaml
-dependencies:
-  localstorage: ^3.0.0
-  url_launcher_fde:
-    git:
-      url: https://github.com/google/flutter-desktop-embedding/
-      path: plugins/flutter_plugins/url_launcher_fde
-```
-
 ## V2 -> v3 migration
 
 V3 doesn't add `.json` extension to a storage filename, so you need to do this on your own if you need a "migration".


### PR DESCRIPTION
was getting an error
```
Could not find a file named "plugins/flutter_plugins/path_provider_fde/pubspec.yaml"
```
`path_provider_fde` does not exist anymore, see [here](https://github.com/google/flutter-desktop-embedding/tree/master/plugins/flutter_plugins)