### PR TITLE
clear() should only clear the fileName of this instance.

### DIFF
--- a/lib/src/directory/web.dart
+++ b/lib/src/directory/web.dart
@@ -16,7 +16,7 @@ class DirUtils implements LocalStorageImpl {
 
   @override
   Future<void> clear() async {
-    localStorage.clear();
+    localStorage.removeItem(fileName);
     storage.add(null);
     _data.clear();
   }


### PR DESCRIPTION
This may have been a typo but I think the intended behavior is to only remove a single top-level entry from localStorage, and not the entire data.