### PR TITLE
Do not call getApplicationDocumentsDirectory() if path is provided

### DIFF
--- a/lib/src/directory/io.dart
+++ b/lib/src/directory/io.dart
@@ -91,8 +91,7 @@ class DirUtils implements LocalStorageImpl {
   }
 
   Future<File> _getFile() async {
-    final dir = await _getDocumentDir();
-    final _path = path ?? dir.path;
+    final _path = path ?? (await _getDocumentDir()).path;
     final _file = File('$_path/$fileName');
     return _file;
   }


### PR DESCRIPTION
This also helps to use the package on platforms where [getApplicationDocumentsDirectory](https://pub.dev/documentation/path_provider/latest/path_provider/getApplicationDocumentsDirectory.html) method is not supported.