### PR TITLE
doc: package version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add dependency to `pubspec.yaml`
 ```yaml
 dependencies:
   ...
-  localstorage: ^3.0.6
+  localstorage: ^4.0.0+1
 ```
 
 Run in your terminal


### PR DESCRIPTION
In the installation part of the main documentation page, the package version is not updated.
This PR fixes the package version issue
Closes issue #74  

## Before
```yaml
dependencies:
  ...
  localstorage: ^3.0.6
```
## After
```yaml
dependencies:
  ...
  localstorage: ^4.0.0+1
```

