### PR TITLE
removing key from cache before disposing

### DIFF
--- a/lib/localstorage.dart
+++ b/lib/localstorage.dart
@@ -33,6 +33,9 @@ class LocalStorage {
   }
 
   void dispose() {
+    if (_cache.containsKey(_dir.fileName)) {
+      _cache.remove(_dir.fileName);
+    }
     _dir.dispose();
   }
 


### PR DESCRIPTION
This request corrects the situation described in this [Issue #94: Unhandled Exception: FileSystemException: File closed](https://github.com/lesnitsky/flutter_localstorage/issues/94):

An error is thrown every time you try to load a new file a second time in the application's lifecycle.

With the fix, during dispose, the code snippet tries to check if the file still exists in the static cache and removes it if it finds it.
