### PR TITLE
Give more control to users over the package performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ ios/Runner/GeneratedPluginRegistrant.*
 
 # ref: https://dart.dev/guides/libraries/private-files
 pubspec.lock 
+
+own_example
+.flutter-plugins
+.flutter-plugins-dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,3 @@ ios/Runner/GeneratedPluginRegistrant.*
 
 # ref: https://dart.dev/guides/libraries/private-files
 pubspec.lock 
-
-own_example
-.flutter-plugins
-.flutter-plugins-dependencies

--- a/README.md
+++ b/README.md
@@ -1,25 +1,9 @@
 # Localstorage
 
-Simple json file-based storage for flutter
+Simple json file-based storage for Flutter that works on all platforms.
 
 [<img src="https://badges.globeapp.dev/twitter" height="40px" />](https://twitter.com/lesnitsky_dev)
 [<img src="https://badges.globeapp.dev/github?owner=lesnitsky&repository=flutter_localstorage" height="40px" />](https://github.com/lesnitsky/flutter_localstorage)
-
-## Installation
-
-Add dependency to `pubspec.yaml`
-
-```yaml
-dependencies:
-  ...
-  localstorage: ^4.0.0+1
-```
-
-Run in your terminal
-
-```sh
-flutter packages get
-```
 
 ## Example
 
@@ -45,6 +29,50 @@ class SomeWidget extends StatelessWidget {
 }
 ```
 
+## Basic features
+
+- Add an item:
+
+```dart
+await storage.setItem("key", "dynamic value");
+```
+
+- Delete an item:
+
+```dart
+await storage.deleteItem("key");
+```
+
+- Get an item:
+
+```dart
+dynamic value = storage.getItem("key");
+```
+
+## Stream and helper features
+
+- Get the size of the JSON file
+
+```dart
+int bytes = await storage.getStorageSize();
+```
+
+- Receive notifications
+
+```dart
+storage.stream.listen((e) {
+  if (e.containsKey("itemWasSet")) {
+    print("an item was set");
+  } else if (e.containsKey("itemWasRemoved")) {
+    print("an item was removed".);
+  } else if (e.containsKey("size")) {
+    print("The JSON file was re-written");
+    int bytes = e['size'];
+    print("And it contains $bytes bytes");
+  }
+});
+```
+
 ## Control over performance
 
 The way it works is that `LocalStorage` stores all the data in a single variable of type `Map<String, dynamic>`, and everytime you update this map, a JSON file, whose name is the key you give when creating an instance of `LocalStorage`, is re-written from zero.
@@ -56,14 +84,15 @@ There is now the possibility to control when the file should be re-written :
 ```dart
 // The key "some_data" will be accessible to you when using `getItem()`.
 // However, it will not be saved on the JSON file,
+// (not stored locally)
 // making this action faster.
 await storage.setItem("some_data", "E=mc2", write: false);
 ```
 
-Obvisouly, you need to save that data on the JSON file at some point. Well, at the end of your big computations, you can just call this method:
+Obviously, you need to save that data on the JSON file at some point. Well, at the end of your big computations, you can just call this method:
 
 ```dart
-storage.writeData();
+await storage.writeData();
 ```
 
 And now all the changes you made to `storage` will be saved locally.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,33 @@ class SomeWidget extends StatelessWidget {
 }
 ```
 
+## Control over performance
+
+The way it works is that `LocalStorage` stores all the data in a single variable of type `Map<String, dynamic>`, and everytime you update this map, a JSON file, whose name is the key you give when creating an instance of `LocalStorage`, is re-written from zero.
+
+Therefore, when storing a big amount of data progressively, you do not want to call `setItem()` or `deleteItem()` multiple times, because the action of re-writing an entire file may take some time.
+
+There is now the possibility to control when the file should be re-written : 
+
+```dart
+// The key "some_data" will be accessible to you when using `getItem()`.
+// However, it will not be saved on the JSON file,
+// making this action faster.
+await storage.setItem("some_data", "E=mc2", write: false);
+```
+
+Obvisouly, you need to save that data on the JSON file at some point. Well, at the end of your big computations, you can just call this method:
+
+```dart
+storage.writeData();
+```
+
+And now all the changes you made to `storage` will be saved locally.
+
+To delete data, it's different. If you call `deleteItem(String key)` then the JSON file will be re-written automatically. To delete multiple items, you must use `deleteItems(List<String> keys)`, which is much more efficient than looping over the keys and calling `deleteItem()` multiple times.
+
+> **NOTE**: to avoid the error: "an asynchronous task is already pending" it would be better to always await a call to `deleteItem()`, `deleteItems()` and `setItem()` when `write` is set to `true`.
+
 ## V2 -> v3 migration
 
 V3 doesn't add `.json` extension to a storage filename, so you need to do this on your own if you need a "migration".

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -63,7 +63,11 @@ class _MyHomePageState extends State<HomePage> {
     super.initState();
     storage = LocalStorage('todo_app.json');
     storage.stream.listen((event) {
-      if (event['size'] != null) {
+      if (event.containsKey("itemWasSet")) {
+        debugPrint("an item was set");
+      } else if (event.containsKey("itemWasRemoved")) {
+        debugPrint("an item was removed");
+      } else if (event['size'] != null) {
         int rawSize = event['size'];
         debugPrint("Size of file : $rawSize");
       }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -54,9 +54,21 @@ class TodoList {
 
 class _MyHomePageState extends State<HomePage> {
   final TodoList list = new TodoList();
-  final LocalStorage storage = new LocalStorage('todo_app.json');
+  late LocalStorage storage;
   bool initialized = false;
   TextEditingController controller = new TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    storage = LocalStorage('todo_app.json');
+    storage.stream.listen((event) {
+      if (event['size'] != null) {
+        int rawSize = event['size'];
+        debugPrint("Size of file : $rawSize");
+      }
+    });
+  }
 
   _toggleItem(TodoItem item) {
     setState(() {

--- a/lib/localstorage.dart
+++ b/lib/localstorage.dart
@@ -9,7 +9,7 @@ class LocalStorage {
   Stream<Map<String, dynamic>> get stream => _dir.stream;
   Map<String, dynamic>? _initialData;
 
-  static final Map<String, LocalStorage> _cache = new Map();
+  static final Map<String, LocalStorage> _cache = {};
 
   late DirUtils _dir;
 
@@ -68,9 +68,10 @@ class LocalStorage {
   /// otherwise `value.toJson()` is called
   Future<void> setItem(
     String key,
-    value, [
-    Object toEncodable(Object nonEncodable)?,
-  ]) async {
+    value, {
+    Object Function(Object nonEncodable)? toEncodable,
+    bool write = true
+  }) async {
     var data = toEncodable?.call(value) ?? null;
     if (data == null) {
       try {
@@ -82,12 +83,25 @@ class LocalStorage {
 
     await _dir.setItem(key, data);
 
+    if (write) _flush(); 
+  }
+
+  /// Saves the data permanently in the JSON file.
+  Future<void> writeData() async {
     return _flush();
   }
 
   /// Removes item from storage by key
   Future<void> deleteItem(String key) async {
     await _dir.remove(key);
+    return _flush();
+  }
+
+  /// Delete multiple entries before saving those changes into the file.
+  Future<void> deleteItems(List<String> keys) async {
+    for (final key in keys) {
+      await _dir.remove(key);
+    }
     return _flush();
   }
 

--- a/lib/localstorage.dart
+++ b/lib/localstorage.dart
@@ -57,6 +57,12 @@ class LocalStorage {
     }
   }
 
+  /// Returns the number of bytes currently stored in the JSON file.
+  /// This function will throw a `PlatformNotSupportedError` if used on the web.
+  Future<int> getStorageSize() async {
+    return await _dir.getFileSize();
+  }
+
   /// Returns a value from storage by key
   dynamic getItem(String key) {
     return _dir.getItem(key);

--- a/lib/src/directory/io.dart
+++ b/lib/src/directory/io.dart
@@ -76,11 +76,13 @@ class DirUtils implements LocalStorageImpl {
   @override
   Future<void> remove(String key) async {
     _data.remove(key);
+    storage.add({ "itemWasRemoved": true });
   }
 
   @override
   Future<void> setItem(String key, dynamic value) async {
     _data[key] = value;
+    storage.add({ "itemWasSet": true });
   }
 
   Future<void> _readFile() async {

--- a/lib/src/directory/io.dart
+++ b/lib/src/directory/io.dart
@@ -49,9 +49,13 @@ class DirUtils implements LocalStorageImpl {
     _file = await _file?.setPosition(0);
     _file = await _file?.writeFrom(buffer);
     _file = await _file?.truncate(buffer.length);
-    final int fileSize = await _file?.length() ?? 0;
-    storage.add({"size": fileSize});
+    storage.add({"size": await getFileSize() });
     await _file?.unlock();
+  }
+
+  @override
+  Future<int> getFileSize() async {
+    return _file == null ? 0 : (await _file!.length());
   }
 
   @override

--- a/lib/src/directory/io.dart
+++ b/lib/src/directory/io.dart
@@ -49,6 +49,8 @@ class DirUtils implements LocalStorageImpl {
     _file = await _file?.setPosition(0);
     _file = await _file?.writeFrom(buffer);
     _file = await _file?.truncate(buffer.length);
+    final int fileSize = await _file?.length() ?? 0;
+    storage.add({"size": fileSize});
     await _file?.unlock();
   }
 

--- a/lib/src/directory/unsupported.dart
+++ b/lib/src/directory/unsupported.dart
@@ -33,6 +33,11 @@ class DirUtils implements LocalStorageImpl {
   }
 
   @override
+  Future<int> getFileSize() {
+    throw PlatformNotSupportedError();
+  }
+
+  @override
   dynamic getItem(String key) {
     throw PlatformNotSupportedError();
   }

--- a/lib/src/directory/web.dart
+++ b/lib/src/directory/web.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:html' as html;
 
+import 'package:localstorage/src/errors.dart';
+
 import '../impl.dart';
 
 class DirUtils implements LocalStorageImpl {
@@ -39,6 +41,11 @@ class DirUtils implements LocalStorageImpl {
   @override
   dynamic getItem(String key) {
     return _data[key];
+  }
+
+  @override
+  Future<int> getFileSize() async {
+    throw PlatformNotSupportedError();
   }
 
   @override

--- a/lib/src/impl.dart
+++ b/lib/src/impl.dart
@@ -12,6 +12,8 @@ abstract class LocalStorageImpl {
 
   Future<void> init([Map<String, dynamic> initialData]);
 
+  Future<int> getFileSize();
+
   Future<void> setItem(String key, dynamic value);
 
   dynamic getItem(String key);

--- a/test/pubspec.yaml
+++ b/test/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   flutter: ^1.5.0
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
My updates allow the developer to better control when the data is written down on the JSON file.

If for example the user is storing a huge amount of data (several megabytes for example), data fetched from a database for a future offline mode maybe, then the developer will want their users to be able to delete the data, or to control it. In the event that multiple keys must be deleted using `deleteItem(String key)`, looping over the keys one by one and calling this method is extremely slow as the file is re-written at every single iteration. That behaviour is not ideal.

My update introduces a new way to control when the write and delete operations are made.

## To delete multiple items:

### BAD

```dart
List<String> keys = ["a", "b", "c"];
for (String key in keys) {
  storage.deleteItem(key);
}
```

### GOOD

```dart
// much faster if there is a lot of data in `storage`
storage.deleteItems(["a", "b", "c"]);
```

## To set multiple items

### BAD

```dart
storage.setItem("a", someBigAmountOfData());
storage.setItem("b", severalMegabytesMaybe());
storage.setItem("c", thatsHuge());
// ...
```

### GOOD

```dart
storage.setItem("a", someBigAmountOfData(), write: false);
storage.setItem("b", severalMegabytesMaybe(), write: false);
storage.setItem("c", thatsHuge(), write: false);
// ...
storage.writeData(); // saves the data locally now
```

## New helper features

- Everytime something is added to the storage (via `setItem()`), the stream emits an event with value: `{ "itemWasSet": true }`
- Same thing when calling `deleteItem()` or `deleteItems()`. The stream emits an event with value: `{ "itemWasRemoved": true }` for each key.
- Everytime the file is being re-written, the stream emits an event with value: `{ "size": some int }` (the number of bytes in the file).

It is also possible to get the exact amount of bytes stored in the JSON file:

```dart
int bytes = await storage.getStorageSize();
print("The file is ${(bytes / 1024).toStringAsFixed(3)} KiB");
```

> NOTE: calling `getStorageSize()` on the web will always raise a `PlatformNotSupportedError`.

## Breaking changes

The only breaking change concerns the parameters of `setItem()`. Indeed, `toEncodable` is no longer an optional positional argument. Here the exact signature:

```dart
// lib/localstorage.dart
Future<void> setItem(
  String key,
  value, {
  Object Function(Object nonEncodable)? toEncodable,
  bool write = true
});
```