### PR TITLE
Add Wasm support

### DIFF
--- a/lib/localstorage.dart
+++ b/lib/localstorage.dart
@@ -1,6 +1,6 @@
 import './src/interface.dart';
 import './src/localstorage_io.dart'
-    if (dart.library.html) './src/localstorage_web.dart';
+    if (dart.library.js_interop) './src/localstorage_web.dart';
 
 export './src/interface.dart';
 


### PR DESCRIPTION
Since dart:html is not supported when compiling to Wasm, the correct alternative now is to use dart.library.js_interop to differentiate between native and web